### PR TITLE
Fixes a loading issue and adds REPO.RELOAD

### DIFF
--- a/jupiter-io/repository1/blubb.txt
+++ b/jupiter-io/repository1/blubb.txt
@@ -1,0 +1,1 @@
+HELLO MOTO

--- a/jupiter-rs/src/repository/background.rs
+++ b/jupiter-rs/src/repository/background.rs
@@ -425,7 +425,7 @@ async fn delete_file_command(path: &str) -> anyhow::Result<()> {
 
 async fn force_reload_command(
     path: &str,
-    files: &Vec<RepositoryFile>,
+    files: &[RepositoryFile],
     change_notifier: &mut mpsc::Sender<BackgroundEvent>,
 ) {
     for file in files {

--- a/jupiter-rs/src/repository/background.rs
+++ b/jupiter-rs/src/repository/background.rs
@@ -356,7 +356,7 @@ async fn sync_lists(
                 .await
             {
                 log::error!(
-                    "Failed to notify frontend about a the delete of {}: {}",
+                    "Failed to notify frontend about the deletion of {}: {}",
                     old_file.name,
                     error
                 );

--- a/jupiter-rs/src/repository/mod.rs
+++ b/jupiter-rs/src/repository/mod.rs
@@ -348,6 +348,11 @@ pub fn install(platform: Arc<Platform>, repository: Arc<Repository>) {
             ForegroundCommands::ForceFetch as usize,
         );
         commands.register_command(
+            "REPO.RELOAD",
+            command_queue.clone(),
+            ForegroundCommands::ForceReload as usize,
+        );
+        commands.register_command(
             "REPO.LIST",
             command_queue.clone(),
             ForegroundCommands::List as usize,

--- a/jupiter-rs/src/response.rs
+++ b/jupiter-rs/src/response.rs
@@ -86,9 +86,9 @@ pub struct Response {
     nesting: Vec<i32>,
 }
 
-/// Represnets a separator used when outputting management data.
+/// Represents a separator used when outputting management data.
 pub static SEPARATOR: &str =
-    "-------------------------------------------------------------------------------\n";
+    "---------------------------------------------------------------------------------------------------\n";
 
 impl Response {
     /// Creates a new response.


### PR DESCRIPTION
We now first emit all "FileDelete" events and then the "FileChanged"
events. This way renaming / moving a loader works as expected
- whereas previously, the loader was loaded (again) and then
unloaded.