### PR TITLE
Makes IDB.LOOKUP and IDB.QUERY case-insensitive (in some cases).

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,23 +163,31 @@ If all modules are enabled, the following commands are available.
   Performs a lookup for the given filter value in the given search path (inner fields separated
   by ".") within the given table. If a result is found, the values for path1..pathN are
   extracted and returned. If no path is given, the number of matches is returned. If multiple
-  documents match, only the first one if returned. Note that if a path matches an inner object
+  documents match, only the first one is returned. Note that if a path matches an inner object
   (which is especially true for "."), the result will be wrapped as JSON.
+  Note that `IDB.LOOKUP` is **case sensitive** by default. However, if a fulltext index is placed on
+  the field being queried, a case insensitive lookup can be performed if the given filter_value
+  is already lowercase. This might be used e.g. for reverse lookups to find a code for a given
+  text in a certain (or any) language. See [repository](jupiter-rs/src/repository) for a description
+  of loaders which ultimately define the tables in IDB and their indices.
 * `IDB.ILOOKUP table primary_lang fallback_lang search_path filter_value path1`
-  Behaves just like `IDB.LOOKUP`.However, of one of the given extraction paths points to an
+  Behaves just like `IDB.LOOKUP`. However, of one of the given extraction paths points to an
   inner map, we expect this to be a map of translation where we first try to find the value for
   the primary language and if none is found for the fallback language. Note that, if both languages
   fail to yield a value, we attempt to resolve a final fallback using **xx** as language
   code. If all these attempts fail, we output an empty string. Note that therefore it is not
   possible to return an inner map when using ILOOKUP which is used for anything other than
   translations. Note however, that extracting single values using a proper path still works.
+  See `IDB.LOOKUP` for details when this is case-sensitive and when it isn't.
 * `IDB.QUERY table num_skip max_results search_path filter_value path1`
   Behaves just like lookup, but doesn't just return the first result, but skips over the first
   `num_skip` results and then outputs up to `max_result` rows. Not that this is again limited to
   at most **1000**.
+  See `IDB.LOOKUP` for details when this is case-sensitive and when it isn't.
 * `IDB.QUERY table primary_lang fallback_lang num_skip max_results search_path filter_value path1`
   Provides essentially the same i18n lookups for `IDB.QUERY` as `IDB.ILOOKUP` does for
   `IDB.LOOKUP`.
+  See `IDB.LOOKUP` for details when this is case-sensitive and when it isn't.
 * `IDB.SEARCH table num_skip max_results search_paths filter_value path1`
   Performs a search in all fields given as `search_paths`. This can either be comma separated
   like "path1,path2,path3" or a "*" to select all fields. Note that for a given search value,

--- a/jupiter-rs/src/idb/table.rs
+++ b/jupiter-rs/src/idb/table.rs
@@ -138,7 +138,6 @@ impl Table {
                 let mut dedup_set = fnv::FnvHashSet::default();
                 let mut additional_index_values = Vec::new();
 
-                // Fetch the exact values..
                 for child in query.execute_all(element) {
                     // Extract all exact matches and insert them into the index...
                     Table::search_values(child, field_name, |field, value| {
@@ -173,15 +172,18 @@ impl Table {
                         // An example would be a list which contains the entries "hello world" and "hello".
                         // As the tokenized version of "hello world" would also emit "hello" (as loose
                         // term) we first want to collect it as exact term.
+                        //
+                        // Note that we index the complete (but lowercased) token as a potential
+                        // exact match - see README.md for details
                         Table::search_values(child, "", |_, value| {
-                            Table::tokenize(value, |token| {
+                            Table::tokenize(value, |token, full_token| {
                                 if !dedup_set.contains(token) {
                                     trie.insert_unique(
                                         token,
                                         IndexEntry {
                                             field: field_symbol,
                                             row,
-                                            exact: false,
+                                            exact: full_token,
                                         },
                                     );
                                     let _ = dedup_set.insert(token.to_string());
@@ -251,18 +253,18 @@ impl Table {
     /// callback.
     fn tokenize<C>(value: &str, mut callback: C)
     where
-        C: FnMut(&str),
+        C: FnMut(&str, bool),
     {
         let effective_value = value.to_lowercase();
-        callback(effective_value.as_str());
+        callback(effective_value.as_str(), true);
 
         for token in effective_value.split(Table::split_pattern) {
             let effective_token = token.trim_matches(|ch: char| !ch.is_alphanumeric());
             if effective_token.len() >= MIN_TOKEN_LENGTH {
-                callback(effective_token);
+                callback(effective_token, false);
                 for inner_token in effective_token.split(|ch: char| !ch.is_alphanumeric()) {
                     if inner_token.len() >= MIN_TOKEN_LENGTH {
-                        callback(inner_token);
+                        callback(inner_token, false);
                     }
                 }
             }
@@ -590,6 +592,7 @@ mod tests {
             vec![
                 IndexType::lookup("code"),
                 IndexType::lookup("iso.two"),
+                IndexType::lookup("mappings"),
                 IndexType::fulltext("name"),
             ],
         )
@@ -601,11 +604,32 @@ mod tests {
         // Check that exact query work...
         let row = table.query("code", "D", true).unwrap().next().unwrap();
         assert_eq!(row.query("name.de").as_str().unwrap(), "Deutschland");
-
-        // Check that inexact queries work...
-        let row = table.query("name", "de", false).unwrap().next().unwrap();
+        // Ensure that exact queries are case sensitive...
+        assert_eq!(
+            table.query("code", "d", true).unwrap().next().is_none(),
+            true
+        );
+        // Ensure that exact queries for which a fulltext index exists, can be case-insensitive
+        // if the search value is already lowercased...
+        let row = table
+            .query("name", "deutschland", true)
+            .unwrap()
+            .next()
+            .unwrap();
         assert_eq!(row.query("name.de").as_str().unwrap(), "Deutschland");
 
+        // Check that inexact queries work...
+        let row = table.query("name", "deu", false).unwrap().next().unwrap();
+        assert_eq!(row.query("name.de").as_str().unwrap(), "Deutschland");
+        let row = table.query("name", "Deu", false).unwrap().next().unwrap();
+        assert_eq!(row.query("name.de").as_str().unwrap(), "Deutschland");
+        // Ensure that exact queries don't match prefixes...
+        assert_eq!(
+            table.query("name", "de", true).unwrap().next().is_none(),
+            true
+        );
+
+        // Ensure that exact queries remain empty if no match is present...
         assert_eq!(
             table.query("name", "xxx", true).unwrap().next().is_none(),
             true
@@ -640,7 +664,7 @@ mod tests {
         assert_eq!(table.table_scan().count(), 2);
 
         // Ensure that the metrics are correctly updated...
-        assert_eq!(table.num_queries(), 5);
+        assert_eq!(table.num_queries(), 12);
         assert_eq!(table.num_scan_queries(), 1);
         assert_eq!(table.num_scans(), 1);
     }


### PR DESCRIPTION
In order for these commands to be case-insensitive, the field being
queried has to have a fulltext index and the search value itself has
to be given as lowercase.

As an example, if a table contains "Austria" in the field **name**, for
which also an fulltext index is defined, a query like `IDB.LOOKUP table name austria`
will match properly.