### PR TITLE
Fix a race condition that lead to missing data in the IDB

### DIFF
--- a/jupiter-io/src/main.rs
+++ b/jupiter-io/src/main.rs
@@ -24,14 +24,17 @@ async fn main() {
     // Setup and enable the LRU cache...
     jupiter::lru::cache::install(platform.clone());
 
-    // Setup and install a data repository...
-    jupiter::repository::install(platform.clone(), jupiter::repository::create(&platform));
+    // Setup a data repository...
+    let repository = jupiter::repository::create(&platform);
 
     // Setup and enable InfoGraphDB...
     jupiter::idb::install(platform.clone());
 
     // Setup pyrun...
     jupiter::pyrun::install(platform.clone());
+
+    // Finally install the data repository after all other actors have registered their loaders
+    jupiter::repository::install(platform.clone(), repository);
 
     platform.require::<Server>().event_loop().await;
 }

--- a/jupiter-rs/src/repository/loader.rs
+++ b/jupiter-rs/src/repository/loader.rs
@@ -256,11 +256,12 @@ pub fn actor(
     mut background_task_sender: mpsc::Sender<BackgroundCommand>,
 ) -> Queue {
     let (command_queue, mut commands_endpoint) = queue();
+    let mut listener = repository.listener();
+
     spawn!(async move {
         use crate::commands::ResultExt;
 
         let mut loaders = HashMap::new();
-        let mut listener = repository.listener();
         let config = platform.require::<Config>();
         let mut config_changed_flag = config.notifier();
         let mut namespaces = load_namespaces(&config);

--- a/jupiter-rs/src/repository/mod.rs
+++ b/jupiter-rs/src/repository/mod.rs
@@ -290,7 +290,11 @@ pub fn create(platform: &Arc<Platform>) -> Arc<Repository> {
 pub fn install(platform: Arc<Platform>, repository: Arc<Repository>) {
     let (background_task_queue, update_notifier) = background::actor(platform.clone());
 
-    let loader_queue = loader::actor(platform.clone(), repository.clone(), background_task_queue.clone());
+    let loader_queue = loader::actor(
+        platform.clone(),
+        repository.clone(),
+        background_task_queue.clone(),
+    );
 
     let command_queue = foreground::actor(
         platform.clone(),

--- a/jupiter-rs/src/repository/mod.rs
+++ b/jupiter-rs/src/repository/mod.rs
@@ -298,8 +298,8 @@ pub fn install(platform: Arc<Platform>, repository: Arc<Repository>) {
 
     let command_queue = foreground::actor(
         platform.clone(),
-        repository.clone(),
-        background_task_queue.clone(),
+        repository,
+        background_task_queue,
         update_notifier,
     );
 

--- a/jupiter-rs/src/repository/mod.rs
+++ b/jupiter-rs/src/repository/mod.rs
@@ -289,14 +289,15 @@ pub fn create(platform: &Arc<Platform>) -> Arc<Repository> {
 /// perform the initial repository scan to determine what contents are already available.
 pub fn install(platform: Arc<Platform>, repository: Arc<Repository>) {
     let (background_task_queue, update_notifier) = background::actor(platform.clone());
+
+    let loader_queue = loader::actor(platform.clone(), repository, background_task_queue);
+
     let command_queue = foreground::actor(
         platform.clone(),
         repository.clone(),
         background_task_queue.clone(),
         update_notifier,
     );
-
-    let loader_queue = loader::actor(platform.clone(), repository, background_task_queue);
 
     if let Some(commands) = platform.find::<CommandDictionary>() {
         commands.register_command(

--- a/jupiter-rs/src/repository/mod.rs
+++ b/jupiter-rs/src/repository/mod.rs
@@ -290,7 +290,7 @@ pub fn create(platform: &Arc<Platform>) -> Arc<Repository> {
 pub fn install(platform: Arc<Platform>, repository: Arc<Repository>) {
     let (background_task_queue, update_notifier) = background::actor(platform.clone());
 
-    let loader_queue = loader::actor(platform.clone(), repository, background_task_queue);
+    let loader_queue = loader::actor(platform.clone(), repository.clone(), background_task_queue.clone());
 
     let command_queue = foreground::actor(
         platform.clone(),


### PR DESCRIPTION
When booting up Jupiter, the foreground actor triggers an initial repository scan in the background actor. It then sends a FileEvent for every file in the repo using a tokio broadcast. The loader actor subscribes to this broadcast and in turn triggers a reload of every loader.

The loader actor subscribed to this broadcast too late, while some FileEvents were already being dispatched. The tokio broadcast drops these first events (as documented), which causes these files to not be loaded.

The first commit moves some code, so that the loader subscribes to the broadcast before the foreground actor starts the repo scan.

The second commit makes sure that the repo scan only happens after all loaders are registered.