### PR TITLE
Detect and prevent dropped broadcast file events

### DIFF
--- a/jupiter-rs/src/repository/foreground.rs
+++ b/jupiter-rs/src/repository/foreground.rs
@@ -107,9 +107,7 @@ pub fn actor(
                 },
                 update = update_notifier.recv() => {
                     match update {
-                        Some(BackgroundEvent::FileEvent(file_event)) => {
-                            let _ = repository.broadcast_sender.send(file_event);
-                        }
+                        Some(BackgroundEvent::FileEvent(file_event)) => repository.send_file_event(file_event).await,
                         Some(BackgroundEvent::FileListUpdated(new_files)) => files = new_files,
                         Some(BackgroundEvent::EpochCounter(epoch)) => background_epoch = epoch,
                         _ => {}

--- a/jupiter-rs/src/repository/loader.rs
+++ b/jupiter-rs/src/repository/loader.rs
@@ -295,11 +295,11 @@ pub fn actor(
                                 log::error!("Failed to remove loader for deleted file {} - {:?}", file.name, e);
                             }
                         }
-                        Err(e) => {
-                            match e {
+                        Err(error) => {
+                            match error {
                                 RecvError::Closed => {}
                                 RecvError::Lagged(count) => {
-                                    log::error!("{} files were not handled, because the event channel is full - {:?}", count, e);
+                                    log::error!("{} files were not handled, because the event channel is full - {:?}", count, error);
                                 }
                             }
                         }

--- a/jupiter-rs/src/repository/mod.rs
+++ b/jupiter-rs/src/repository/mod.rs
@@ -119,7 +119,7 @@ use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use anyhow::Context;
 use tokio::sync::broadcast;
@@ -128,6 +128,8 @@ use crate::commands::CommandDictionary;
 use crate::platform::Platform;
 use crate::repository::foreground::ForegroundCommands;
 use crate::repository::loader::{Loader, LoaderCommands};
+
+const FILE_EVENT_BROADCAST_BUFFER_SIZE: usize = 128;
 
 mod background;
 mod foreground;
@@ -199,7 +201,7 @@ pub struct Repository {
 
 impl Repository {
     fn new() -> Self {
-        let (broadcast_sender, _) = broadcast::channel(128);
+        let (broadcast_sender, _) = broadcast::channel(FILE_EVENT_BROADCAST_BUFFER_SIZE);
 
         Repository {
             broadcast_sender,
@@ -267,6 +269,18 @@ impl Repository {
 
     fn listener(&self) -> FileEventReceiver {
         self.broadcast_sender.subscribe()
+    }
+
+    async fn send_file_event(&self, file_event: FileEvent) {
+        if self.broadcast_sender.len() >= FILE_EVENT_BROADCAST_BUFFER_SIZE {
+            log::debug!(
+                "Pausing sending file events for 2 seconds because the broadcast buffer is full"
+            );
+
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+
+        let _ = self.broadcast_sender.send(file_event);
     }
 }
 

--- a/jupiter-rs/src/repository/mod.rs
+++ b/jupiter-rs/src/repository/mod.rs
@@ -272,12 +272,17 @@ impl Repository {
     }
 
     async fn send_file_event(&self, file_event: FileEvent) {
-        if self.broadcast_sender.len() >= FILE_EVENT_BROADCAST_BUFFER_SIZE {
+        let mut attempt = 0;
+
+        while self.broadcast_sender.len() >= FILE_EVENT_BROADCAST_BUFFER_SIZE && attempt < 10 {
+            attempt += 1;
+
             log::debug!(
-                "Pausing sending file events for 2 seconds because the broadcast buffer is full"
+                "Pausing sending file events for 1 second because the broadcast buffer is full (Attempt {} of 10)",
+                attempt
             );
 
-            tokio::time::sleep(Duration::from_secs(2)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
 
         let _ = self.broadcast_sender.send(file_event);


### PR DESCRIPTION
When scanning the entire repo, the broadcast channel would clog up, which causes file events to be dropped.

This logs dropped events, and also tries to slow down scanning if the broadcast buffer is full.

Fixes: SIRI-994