### PR TITLE
Enables multi-arch Docker builds for Jupiter IO

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.idea
+target
+jupiter-rs/target
+jupiter-io/target
+jupiter-io/repository*
+jupiter-io/settings.yml
+jupiter_test_config.yml

--- a/.drone.yml
+++ b/.drone.yml
@@ -85,11 +85,16 @@ steps:
         - tag
 
   - name: publish
-    image: plugins/docker
+    image: owncloudci/drone-docker-buildx
+    privileged: true
     volumes: *scireum_volumes
     settings:
       dockerfile: jupiter-io/Dockerfile
+      context: .
       repo: scireum/jupiter-io
+      platforms:
+        - linux/amd64
+        - linux/arm64
       tags:
         - "${DRONE_TAG}"
     environment:

--- a/jupiter-io/Dockerfile
+++ b/jupiter-io/Dockerfile
@@ -1,7 +1,20 @@
+FROM rust:1.92-slim AS builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libssl-dev pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY jupiter-rs ./jupiter-rs
+COPY jupiter-io ./jupiter-io
+
+WORKDIR /src/jupiter-io
+RUN cargo build --release
+
 FROM rust:1.92-slim
 
 RUN mkdir /jupiter
-COPY /jupiter-io/target/release/jupiter-io /jupiter/jupiter-io
+COPY --from=builder /src/jupiter-io/target/release/jupiter-io /jupiter/jupiter-io
 RUN chmod +x /jupiter/jupiter-io
 
 VOLUME /jupiter/config

--- a/jupiter-io/Dockerfile
+++ b/jupiter-io/Dockerfile
@@ -1,20 +1,31 @@
+# syntax=docker/dockerfile:1
+
 FROM rust:1.92-slim AS builder
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libssl-dev pkg-config && \
-    rm -rf /var/lib/apt/lists/*
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends libssl-dev pkg-config
 
 WORKDIR /src
 COPY jupiter-rs ./jupiter-rs
 COPY jupiter-io ./jupiter-io
 
 WORKDIR /src/jupiter-io
-RUN cargo build --release
+ARG TARGETARCH
+RUN --mount=type=cache,id=jupiter-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=jupiter-cargo-git,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=jupiter-target-${TARGETARCH},target=/src/jupiter-io/target,sharing=locked \
+    cargo build --release && \
+    cp /src/jupiter-io/target/release/jupiter-io /usr/local/bin/jupiter-io
 
 FROM rust:1.92-slim
 
 RUN mkdir /jupiter
-COPY --from=builder /src/jupiter-io/target/release/jupiter-io /jupiter/jupiter-io
+COPY --from=builder /usr/local/bin/jupiter-io /jupiter/jupiter-io
 RUN chmod +x /jupiter/jupiter-io
 
 VOLUME /jupiter/config


### PR DESCRIPTION
### Description

The Docker image now builds the Rust binary inside the target-platform Docker build instead of copying a host-built release artifact. This lets Buildx produce valid linux/amd64 and linux/arm64 images. The Drone publish step now uses the buildx-capable Docker plugin and the Docker context ignores local build output and development files.

### Checklist

- [x] Code change has been tested and works locally
- [x] Code was formatted via 'cargo fmt' and follows 'cargo clippy' & [best practices](https://scireum.myjetbrains.com/youtrack/articles/MISC-A-16/CodeStyle-JavaDoc)
- [ ] Patch Tasks: Is local execution of Patch Tasks necessary? If so, please also mark the PR with the tag.
