### PR TITLE
Limit Docker socket to Docker publish steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -91,7 +91,7 @@ steps:
   - name: publish
     image: owncloudci/drone-docker-buildx
     privileged: true
-    volumes: *scireum_volumes
+    volumes: *scireum_cargo_docker_volumes
     settings:
       dockerfile: jupiter-io/Dockerfile
       context: .

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,9 @@
 ---
-scireum_volumes: &scireum_volumes
+scireum_cargo_volumes: &scireum_cargo_volumes
+  - name: cargo
+    path: /var/.cargo
+
+scireum_cargo_docker_volumes: &scireum_cargo_docker_volumes
   - name: docker_socket
     path: /var/run/docker.sock
   - name: cargo
@@ -18,7 +22,7 @@ clone:
 steps:
   - name: compile
     image: rust:1.92
-    volumes: *scireum_volumes
+    volumes: *scireum_cargo_volumes
     commands:
       - export CARGO_HOME="/var/.cargo"
       - echo $CARGO_HOME
@@ -34,7 +38,7 @@ steps:
 
   - name: test
     image: rust:1.92
-    volumes: *scireum_volumes
+    volumes: *scireum_cargo_volumes
     commands:
       - export CARGO_HOME="/var/.cargo"
       - echo $CARGO_HOME
@@ -52,7 +56,7 @@ steps:
 
   - name: package
     image: rust:1.92
-    volumes: *scireum_volumes
+    volumes: *scireum_cargo_volumes
     commands:
       - export CARGO_HOME="/var/.cargo"
       - echo $CARGO_HOME
@@ -86,7 +90,7 @@ steps:
 
   - name: publish
     image: plugins/docker
-    volumes: *scireum_volumes
+    volumes: *scireum_cargo_docker_volumes
     settings:
       dockerfile: jupiter-io/Dockerfile
       repo: scireum/jupiter-io


### PR DESCRIPTION
## Summary
- Split cache-only and Docker-enabled Drone volume anchors.
- Use cache-only volumes for compile, test, package and sonar steps.
- Keep Docker socket mounts only on Docker plugin or buildx steps.

## Test plan
- Not run; Drone CI configuration only.